### PR TITLE
Display pet events, add new event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "firebase": "^9.19.1",
         "localforage": "^1.10.0",
         "match-sorter": "^6.3.1",
+        "moment": "^2.29.4",
         "react": "^18.1.0",
         "react-bootstrap": "^2.7.3",
         "react-bootstrap-icons": "^1.10.3",
@@ -12044,6 +12045,14 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -25920,6 +25929,11 @@
       "requires": {
         "minimist": "^1.2.6"
       }
+    },
+    "moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "firebase": "^9.19.1",
     "localforage": "^1.10.0",
     "match-sorter": "^6.3.1",
+    "moment": "^2.29.4",
     "react": "^18.1.0",
     "react-bootstrap": "^2.7.3",
     "react-bootstrap-icons": "^1.10.3",

--- a/src/App.css
+++ b/src/App.css
@@ -119,7 +119,8 @@
 
 .react-select__placeholder,
 .react-select__single-value,
-.react-select__menu {
+.react-select__menu,
+.form-check {
   text-align: start;
 }
 
@@ -142,14 +143,28 @@
   border-radius: 1vmin;
 }
 
+/* Event form */
+.form-check-input:checked {
+  background-color: #2d4059;
+  border-color: #2d4059;
+}
+
 /* Buttons */
-.btn-container {
+.bottom-btn-container {
   position: absolute;
+  display: flex;
   flex-direction: column;
   justify-content: center;
   right: calc(10px + 1vmin);
   bottom: calc(10px + 1vmin);
+}
+
+.top-btn-container {
+  position: absolute;
   display: flex;
+  align-items: center;
+  top: 2vmin;
+  left: 2vmin;
 }
 
 .custom-btn {

--- a/src/App.css
+++ b/src/App.css
@@ -156,6 +156,13 @@
 }
 
 /* Event form */
+.profile-xs {
+  object-fit: cover;
+  width: 5vh;
+  height: 5vh;
+  border-radius: 50%;
+}
+
 .form-check-input:checked {
   background-color: #2d4059;
   border-color: #2d4059;

--- a/src/App.css
+++ b/src/App.css
@@ -53,6 +53,11 @@
   justify-content: center;
 }
 
+.flex-container-space-btw {
+  display: flex;
+  justify-content: space-between;
+}
+
 .margin-tb-m {
   margin: 2vmin 0;
 }
@@ -133,14 +138,21 @@
 }
 
 .events-container {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  width: 80%;
+  width: 100%;
   max-width: 500px;
+}
+
+.accordion-button {
+  padding: 2vmin;
+}
+
+.day-events-container {
+  padding: 0;
+}
+
+.event-item {
   padding: 1vmin;
-  border-radius: 1vmin;
+  /* border: 0.5px #ffffff solid; */
 }
 
 /* Event form */

--- a/src/Components/Alerts.js
+++ b/src/Components/Alerts.js
@@ -1,0 +1,23 @@
+import { ToastContainer, Toast } from "react-bootstrap";
+
+export default function Alerts(props) {
+  const toastMessages = {
+    petFormCompletion: "Please complete your pet's profile.",
+    eventFormCompletion: "Make sure you include a start time.",
+  };
+
+  return (
+    <ToastContainer position="bottom-center" className="margin-tb-sm">
+      <Toast
+        show={props.showAlert}
+        onClose={props.hideAlert}
+        delay={3000}
+        autohide
+      >
+        <Toast.Body className="dark small">
+          {toastMessages[props.alertKey]}
+        </Toast.Body>
+      </Toast>
+    </ToastContainer>
+  );
+}

--- a/src/Components/Alerts.js
+++ b/src/Components/Alerts.js
@@ -3,7 +3,9 @@ import { ToastContainer, Toast } from "react-bootstrap";
 export default function Alerts(props) {
   const toastMessages = {
     petFormCompletion: "Please complete your pet's profile.",
-    eventFormCompletion: "Make sure you include a start time.",
+    eventFormCompletion:
+      "Make sure you include the category, sub-category, and start time.",
+    reminderSet: `PawPal will remind you about ${props.petName}'s next ${props.topic}.`,
   };
 
   return (

--- a/src/Components/EventForm.js
+++ b/src/Components/EventForm.js
@@ -1,0 +1,323 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import axios from "axios";
+import { storage } from "../Firebase.js";
+import { ref, getDownloadURL, uploadBytes } from "firebase/storage";
+import { Form, FloatingLabel, Button, Spinner } from "react-bootstrap";
+import Select from "react-select";
+import CreatableSelect from "react-select/creatable";
+import { BACKEND_URL, USERID } from "../Constants.js";
+import Alerts from "./Alerts.js";
+import { ArrowLeftShort } from "react-bootstrap-icons";
+import moment from "moment";
+
+export default function EventForm() {
+  const navigate = useNavigate();
+  const { petId } = useParams();
+  const [categoryList, setCategoryList] = useState([]);
+  const [subcategoryList, setSubcategoryList] = useState([]);
+  const [newSubcategory, setNewSubcategory] = useState(null);
+  const [event, setEvent] = useState({
+    categoryId: "",
+    subcategoryId: "",
+    startTime: moment(new Date()).format("YYYY-MM-DDTHH:mm"),
+    endTime: moment(new Date()).format("YYYY-MM-DDTHH:mm"),
+    causeForConcern: false,
+    description: "",
+    data: "",
+    unit: "",
+    imageUrl: "",
+    remindMe: false,
+  });
+  const [imageFile, setImageFile] = useState("");
+  const [imageInputValue, setImageInputValue] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [showAlert, setShowAlert] = useState(false);
+  const [alertKey, setAlertKey] = useState("");
+
+  useEffect(() => {
+    getCategories();
+  }, []);
+
+  const getCategories = async () => {
+    const categories = await axios.get(
+      `${BACKEND_URL}/users/${USERID}/pets/${petId}/events/categories`
+    );
+    setCategoryList(categories.data);
+  };
+
+  useEffect(() => {
+    getSubcategories();
+  }, [event.categoryId]);
+
+  const getSubcategories = async () => {
+    if (!event.categoryId) {
+      return;
+    }
+    const subcategories = await axios.get(
+      `${BACKEND_URL}/users/${USERID}/pets/${petId}/events/categories/${event.categoryId}/subcategories`
+    );
+    setSubcategoryList(subcategories.data);
+  };
+
+  const handleSelect = (selected) => {
+    const eventToUpdate = { ...event };
+    eventToUpdate[selected.name] = selected.value;
+    setEvent(eventToUpdate);
+  };
+
+  const handleCreatableSelect = (selected) => {
+    if (selected.__isNew__) {
+      const newValue =
+        selected.value[0].toUpperCase() + selected.value.substring(1);
+      setNewSubcategory({ name: newValue });
+    } else {
+      handleSelect(selected);
+    }
+  };
+
+  const handleChange = (e) => {
+    const eventToUpdate = { ...event };
+    eventToUpdate[e.target.name] = e.target.value;
+    setEvent(eventToUpdate);
+  };
+
+  const handleFileChange = (e) => {
+    setImageInputValue(e.target.value);
+    setImageFile(e.target.files[0]);
+  };
+
+  const handleSwitch = (e) => {
+    const eventToUpdate = { ...event };
+    eventToUpdate[e.target.name] = !eventToUpdate[e.target.name];
+    setEvent(eventToUpdate);
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!event.startTime) {
+      setShowAlert(true);
+      setAlertKey("eventFormCompletion");
+      return;
+    }
+    setSubmitting(true);
+
+    const newSubcategoryId = await createSubcategory();
+    const imageUrl = await uploadFile();
+    await writeData(imageUrl, newSubcategoryId);
+  };
+
+  const createSubcategory = async () => {
+    if (!newSubcategory) {
+      return null;
+    }
+    try {
+      const newSubcategoryRes = await axios.post(
+        `${BACKEND_URL}/users/${USERID}/pets/${petId}/events/categories/${event.categoryId}/subcategories`,
+        newSubcategory
+      );
+      return newSubcategoryRes.data.id;
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
+  const uploadFile = async () => {
+    if (!imageFile) {
+      return Promise.resolve("");
+    }
+    const fileRef = ref(storage, `pet-profiles/${imageFile.name}`);
+    return uploadBytes(fileRef, imageFile)
+      .then(() => getDownloadURL(fileRef))
+      .catch((err) => {
+        console.log(err);
+      });
+  };
+
+  const writeData = async (imageUrl, newSubcategoryId) => {
+    const requestBody = { ...event, imageUrl };
+    if (newSubcategoryId) {
+      requestBody.subcategoryId = newSubcategoryId;
+    }
+    if (!requestBody.endTime) {
+      requestBody.endTime = new Date().toISOString();
+    }
+    for (const key in requestBody) {
+      if (!requestBody[key]) {
+        delete requestBody[key];
+      }
+    }
+    try {
+      await axios.post(
+        `${BACKEND_URL}/users/${USERID}/pets/${petId}/events`,
+        requestBody
+      );
+    } catch (err) {
+      console.log(err);
+    }
+
+    setEvent({
+      categoryId: "",
+      subcategoryId: "",
+      startTime: moment(new Date()).format("YYYY-MM-DDTHH:mm"),
+      endTime: moment(new Date()).format("YYYY-MM-DDTHH:mm"),
+      causeForConcern: false,
+      description: "",
+      data: "",
+      unit: "",
+      imageUrl: "",
+      remindMe: false,
+    });
+    setImageFile("");
+    setImageInputValue("");
+    navigate(`/my-pets/${petId}`);
+  };
+
+  return (
+    <div className="App">
+      <header className="App-header">
+        <div
+          className="top-btn-container bold"
+          onClick={() => {
+            navigate(-1);
+          }}
+        >
+          <ArrowLeftShort />
+          Back
+        </div>
+        <h1 className="x-large">New activity</h1>
+        <Form className="margin-lr-m" onSubmit={handleSubmit}>
+          <Form.Group className="margin-tb-m">
+            <Select
+              className="react-select-container"
+              classNamePrefix="react-select"
+              placeholder="Select a category"
+              isSearchable={true}
+              options={categoryList.map((category) => {
+                return {
+                  value: category.id,
+                  label: category.name,
+                  name: "categoryId",
+                };
+              })}
+              onChange={handleSelect}
+              styles={{
+                option: (provided) => ({
+                  ...provided,
+                  color: "#222831",
+                }),
+              }}
+            />
+          </Form.Group>
+          <Form.Group className="margin-tb-m">
+            <CreatableSelect
+              className="react-select-container"
+              classNamePrefix="react-select"
+              placeholder="Select or create a subcategory"
+              isSearchable={true}
+              options={subcategoryList.map((subcat) => {
+                return {
+                  value: subcat.id,
+                  label: subcat.name,
+                  name: "subcategoryId",
+                };
+              })}
+              onChange={handleCreatableSelect}
+              styles={{
+                option: (provided) => ({
+                  ...provided,
+                  color: "#222831",
+                }),
+              }}
+            />
+          </Form.Group>
+          <Form.Group className="margin-tb-m">
+            <Form.Control
+              name="description"
+              type="text"
+              as="textarea"
+              rows={2}
+              value={event.description}
+              onChange={handleChange}
+              placeholder="More details (optional)"
+            />
+          </Form.Group>
+          <Form.Group className="margin-tb-m">
+            <FloatingLabel className="dark" label="Started at">
+              <Form.Control
+                name="startTime"
+                type="datetime-local"
+                value={event.startTime}
+                onChange={handleChange}
+              />
+            </FloatingLabel>
+          </Form.Group>
+          <Form.Group className="margin-tb-m">
+            <FloatingLabel className="dark" label="Ended at">
+              <Form.Control
+                name="endTime"
+                type="datetime-local"
+                value={event.endTime}
+                onChange={handleChange}
+              />
+            </FloatingLabel>
+          </Form.Group>
+          <Form.Group className="margin-tb-m">
+            <FloatingLabel className="dark" label="Upload a photo (optional)">
+              <Form.Control
+                name="imageUrl"
+                type="file"
+                value={imageInputValue}
+                onChange={handleFileChange}
+              />
+            </FloatingLabel>
+          </Form.Group>
+          <Form.Group className="margin-tb-m">
+            <Form.Check
+              type="switch"
+              className="margin-lr-m"
+              name="causeForConcern"
+              label="I'm concerned"
+              value={event.causeForConcern}
+              onChange={handleSwitch}
+            />
+            <Form.Check
+              type="switch"
+              name="remindMe"
+              className="margin-lr-m"
+              label="Set a reminder"
+              value={event.remindMe}
+              onChange={handleSwitch}
+            />
+          </Form.Group>
+
+          <Form.Group className="margin-tb-m">
+            {submitting ? (
+              <Button variant="light" disabled>
+                <Spinner
+                  as="span"
+                  animation="border"
+                  size="sm"
+                  role="status"
+                  aria-hidden="true"
+                />
+                <span className="visually-hidden">Submitting...</span>
+              </Button>
+            ) : (
+              <Button type="submit" variant="light">
+                Submit
+              </Button>
+            )}
+          </Form.Group>
+        </Form>
+        <Alerts
+          showAlert={showAlert}
+          hideAlert={() => {
+            setShowAlert(false);
+          }}
+          alertKey={alertKey}
+        />
+      </header>
+    </div>
+  );
+}

--- a/src/Components/Events.js
+++ b/src/Components/Events.js
@@ -1,11 +1,13 @@
 import { useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import axios from "axios";
 import { BACKEND_URL, USERID } from "../Constants.js";
 import { calculateAge, calculateDuration, sortEventsByDay } from "../Utils.js";
+import { PlusCircleFill, ArrowLeftShort } from "react-bootstrap-icons";
 
 export default function Events() {
   const { petId } = useParams();
+  const navigate = useNavigate();
 
   const [petProfile, setPetProfile] = useState({});
 
@@ -79,8 +81,25 @@ export default function Events() {
 
   return (
     <header className="App-header">
+      <div
+        className="top-btn-container bold"
+        onClick={() => {
+          navigate(-1);
+        }}
+      >
+        <ArrowLeftShort />
+        Back
+      </div>
       {displayProfile()}
       {displayEvents()}
+      <div className="bottom-btn-container">
+        <PlusCircleFill
+          className="custom-btn"
+          onClick={() => {
+            navigate("./add-activity");
+          }}
+        />
+      </div>
     </header>
   );
 }

--- a/src/Components/Events.js
+++ b/src/Components/Events.js
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from "react-router-dom";
 import axios from "axios";
 import { BACKEND_URL, USERID } from "../Constants.js";
 import { calculateAge, calculateDuration, sortEventsByDay } from "../Utils.js";
+import { Accordion, Badge } from "react-bootstrap";
 import { PlusCircleFill, ArrowLeftShort } from "react-bootstrap-icons";
 
 export default function Events() {
@@ -10,6 +11,7 @@ export default function Events() {
   const navigate = useNavigate();
 
   const [petProfile, setPetProfile] = useState({});
+  const [petEvents, setPetEvents] = useState([]);
 
   useEffect(() => {
     retrievePetProfile();
@@ -20,6 +22,17 @@ export default function Events() {
       `${BACKEND_URL}/users/${USERID}/pets/${petId}`
     );
     setPetProfile(profile.data[0]);
+  };
+
+  useEffect(() => {
+    retrievePetEvents();
+  }, []);
+
+  const retrievePetEvents = async () => {
+    const events = await axios.get(
+      `${BACKEND_URL}/users/${USERID}/pets/${petId}/events`
+    );
+    setPetEvents(events.data);
   };
 
   const displayProfile = () => {
@@ -42,40 +55,61 @@ export default function Events() {
   };
 
   const displayEvents = () => {
-    if (!petProfile.events) {
+    if (!petEvents) {
       return;
-    } else if (petProfile.events.length === 0) {
-      return (
-        <div className="events-container">
-          {petProfile.name} doesn't have any activities yet!
-        </div>
-      );
+    } else if (petEvents.length === 0) {
+      return <div>{petProfile.name} doesn't have any activities yet!</div>;
     } else {
-      const output = [];
-      const sortedEvents = sortEventsByDay(petProfile.events);
-      for (const key in sortedEvents) {
-        const eventsOfDay = [
-          <div className="bold small" key={key}>
-            {key}
-          </div>,
-        ];
-        for (const event of sortedEvents[key]) {
-          eventsOfDay.push(
-            <div key={event.id} className="flex-container">
-              <div className="small margin-lr-sm">{event.name}</div>
+      const bgVariants = [
+        "primary",
+        "warning",
+        "secondary",
+        "dark",
+        "success",
+        "danger",
+        "info",
+      ];
+      const eventsByDay = sortEventsByDay(petEvents);
+      const eventsList = [];
+      let counter = 0;
+      for (const day in eventsByDay) {
+        const dayEventsList = [];
+        for (const event of eventsByDay[day]) {
+          dayEventsList.push(
+            <div className="event-item flex-container-space-btw" key={event.id}>
               <div className="small margin-lr-sm">
-                {calculateDuration(event)}
+                {event.subcategory.name} ({calculateDuration(event)})
               </div>
+              <Badge
+                className="small margin-lr-sm"
+                bg={bgVariants[event.categoryId - 1]}
+                text={event.categoryId === 2 && "dark"}
+              >
+                {event.category.name}
+              </Badge>
             </div>
           );
         }
-        output.push(
-          <div className="margin-tb-m events-container" key={key}>
-            {eventsOfDay}
-          </div>
+        eventsList.push(
+          <Accordion.Item key={day} eventKey={counter}>
+            <Accordion.Header>{day}</Accordion.Header>
+            <Accordion.Body className="day-events-container">
+              {dayEventsList}
+            </Accordion.Body>
+          </Accordion.Item>
         );
+        counter++;
       }
-      return <div className="events-container">{output}</div>;
+      return (
+        <Accordion
+          className="events-container"
+          flush
+          alwaysOpen
+          defaultActiveKey={[0]}
+        >
+          {eventsList}
+        </Accordion>
+      );
     }
   };
 

--- a/src/Components/MyPets.js
+++ b/src/Components/MyPets.js
@@ -5,6 +5,7 @@ import { BACKEND_URL, USERID } from "../Constants.js";
 import Carousel from "react-bootstrap/Carousel";
 import { calculateAge } from "../Utils.js";
 import { PlusCircleFill } from "react-bootstrap-icons";
+import Reminders from "./Reminders.js";
 
 export default function MyPets() {
   const PLACEHOLDER_PIC =
@@ -54,6 +55,7 @@ export default function MyPets() {
   return (
     <div className="App">
       <header className="App-header">
+        <Reminders />
         {/* Note: authenticated users see a summary of pet profiles */}
         <Carousel
           activeIndex={index}

--- a/src/Components/MyPets.js
+++ b/src/Components/MyPets.js
@@ -63,7 +63,7 @@ export default function MyPets() {
         >
           {displayPets()}
         </Carousel>
-        <div className="btn-container">
+        <div className="bottom-btn-container">
           <PlusCircleFill
             className="custom-btn"
             onClick={() => {

--- a/src/Components/PetForm.js
+++ b/src/Components/PetForm.js
@@ -6,6 +6,7 @@ import { ref, getDownloadURL, uploadBytes } from "firebase/storage";
 import { Form, FloatingLabel, Button, Spinner } from "react-bootstrap";
 import Select from "react-select";
 import { BACKEND_URL, USERID } from "../Constants.js";
+import Alerts from "./Alerts.js";
 
 export default function PetForm() {
   const navigate = useNavigate();
@@ -20,6 +21,8 @@ export default function PetForm() {
   const [imageFile, setImageFile] = useState("");
   const [imageInputValue, setImageInputValue] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  const [showAlert, setShowAlert] = useState(false);
+  const [alertKey, setAlertKey] = useState("");
 
   useEffect(() => {
     getSpecies();
@@ -65,10 +68,12 @@ export default function PetForm() {
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    setSubmitting(true);
     if (!profile.speciesId || !profile.name) {
-      alert("Please complete your pet's profile.");
+      setShowAlert(true);
+      setAlertKey("petFormCompletion");
+      return;
     }
+    setSubmitting(true);
     uploadFile()
       .then((imageUrl) => writeData(imageUrl))
       .catch((error) => {
@@ -197,6 +202,13 @@ export default function PetForm() {
             )}
           </Form.Group>
         </Form>
+        <Alerts
+          showAlert={showAlert}
+          hideAlert={() => {
+            setShowAlert(false);
+          }}
+          alertKey={alertKey}
+        />
       </header>
     </div>
   );

--- a/src/Components/PetForm.js
+++ b/src/Components/PetForm.js
@@ -7,6 +7,7 @@ import { Form, FloatingLabel, Button, Spinner } from "react-bootstrap";
 import Select from "react-select";
 import { BACKEND_URL, USERID } from "../Constants.js";
 import Alerts from "./Alerts.js";
+import { ArrowLeftShort } from "react-bootstrap-icons";
 
 export default function PetForm() {
   const navigate = useNavigate();
@@ -90,10 +91,13 @@ export default function PetForm() {
   };
 
   const writeData = async (imageUrl) => {
-    await axios.post(`${BACKEND_URL}/users/${USERID}/pets/`, {
-      ...profile,
-      imageUrl,
-    });
+    const requestBody = { ...profile, imageUrl };
+    for (const key in requestBody) {
+      if (!requestBody[key]) {
+        delete requestBody[key];
+      }
+    }
+    await axios.post(`${BACKEND_URL}/users/${USERID}/pets/`, requestBody);
     setProfile({
       speciesId: "",
       breedId: "",
@@ -108,6 +112,15 @@ export default function PetForm() {
   return (
     <div className="App">
       <header className="App-header">
+        <div
+          className="top-btn-container bold"
+          onClick={() => {
+            navigate(-1);
+          }}
+        >
+          <ArrowLeftShort />
+          Back
+        </div>
         <h1 className="x-large">New pet</h1>
         <Form className="margin-lr-m" onSubmit={handleSubmit}>
           <Form.Group className="margin-tb-m">

--- a/src/Components/Reminders.js
+++ b/src/Components/Reminders.js
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+import axios from "axios";
+import { ToastContainer, Toast } from "react-bootstrap";
+import { AlarmFill } from "react-bootstrap-icons";
+import { BACKEND_URL, USERID } from "../Constants.js";
+
+export default function Reminders(props) {
+  const [reminders, setReminders] = useState([]);
+
+  useEffect(() => {
+    getReminders();
+  }, []);
+
+  const getReminders = async () => {
+    const remindersRes = await axios.get(
+      `${BACKEND_URL}/users/${USERID}/reminders`
+    );
+    setReminders(remindersRes.data);
+  };
+
+  const displayToasts = () => {
+    return reminders.map((reminder, index) => (
+      <Toast
+        key={reminder.eventId}
+        name={index}
+        show={reminder.showReminder}
+        onClose={() => {
+          const remindersToUpdate = [...reminders];
+          remindersToUpdate[index].showReminder = false;
+          setReminders(remindersToUpdate);
+        }}
+      >
+        <Toast.Header>
+          <strong className="me-auto">
+            <AlarmFill />
+          </strong>
+        </Toast.Header>
+        <Toast.Body className="dark small">{reminder.content}</Toast.Body>
+      </Toast>
+    ));
+  };
+
+  return (
+    <ToastContainer position="top-center" className="margin-tb-sm">
+      {displayToasts()}
+    </ToastContainer>
+  );
+}

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -21,10 +21,10 @@ export const calculateDuration = (petEvent) => {
   const durationInMins = (end - start) / 1000 / 60;
   if (durationInMins >= 60) {
     const durationInHours = Math.floor(durationInMins / 60);
-    const remainingMins = durationInMins - durationInHours * 60;
+    const remainingMins = Math.floor(durationInMins % 60);
     return `${durationInHours}h${remainingMins}min`;
   } else {
-    return `${durationInMins}min`;
+    return `${Math.floor(durationInMins)}min`;
   }
 };
 

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -15,9 +15,16 @@ export const calculateAge = (dateOfBirth) => {
   }
 };
 
-export const calculateDuration = (petEvent) => {
-  const start = new Date(petEvent.startTime);
-  const end = new Date(petEvent.endTime);
+export const calculateDuration = (petEvent, byStartTime = true) => {
+  let start;
+  let end;
+  if (byStartTime) {
+    start = new Date(petEvent.startTime);
+    end = new Date(petEvent.endTime);
+  } else {
+    start = new Date(petEvent.createdAt);
+    end = new Date();
+  }
   const durationInMins = (end - start) / 1000 / 60;
   if (durationInMins >= 60) {
     const durationInHours = Math.floor(durationInMins / 60);

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import MyPets from "./Components/MyPets.js";
 import Navigation from "./Components/Navigation.js";
 import Events from "./Components/Events.js";
 import PetForm from "./Components/PetForm.js";
+import EventForm from "./Components/EventForm.js";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
@@ -17,6 +18,7 @@ root.render(
       <Route path="/my-pets" element={<MyPets />} />
       <Route path="/my-pets/add-pet" element={<PetForm />} />
       <Route path="/my-pets/:petId" element={<Events />} />
+      <Route path="/my-pets/:petId/add-activity" element={<EventForm />} />
     </Routes>
   </BrowserRouter>
 );


### PR DESCRIPTION
Enhanced display of pet events, organized by day in expandable accordion, with colored category tags:
<img width="360" alt="Screenshot 2023-04-18 at 10 18 41 PM" src="https://user-images.githubusercontent.com/48173359/232808076-a72ee82a-37bd-48ae-bd98-a43eefdc8634.png">

New form component to send a new event post request to the backend (a toast appears if the users selects "remind me"):
<img width="359" alt="Screenshot 2023-04-20 at 12 09 59 PM" src="https://user-images.githubusercontent.com/48173359/233256170-7bae5ff3-8a1c-4050-82f7-d5adc1cd0515.png">

New reminders component that sends a request to the backend and displays the reminders (the logic of what goes into the reminders is handled at the backend).
<img width="360" alt="Screenshot 2023-04-20 at 12 09 03 PM" src="https://user-images.githubusercontent.com/48173359/233256307-960a38cb-3348-43a1-bd87-6dd1d2923335.png">
