### PR TITLE
Frontend auth (phase 1): sign in and stay logged in

### DIFF
--- a/src/Axios.js
+++ b/src/Axios.js
@@ -1,0 +1,13 @@
+import axios from "axios";
+
+const BACKEND_URL = "http://localhost:3000";
+
+export const axiosDefault = axios.create({
+  baseURL: BACKEND_URL,
+});
+
+export const axiosPrivate = axios.create({
+  baseURL: BACKEND_URL,
+  headers: { "Content-Type": "applications/json" },
+  withCredentials: true,
+});

--- a/src/Axios.js
+++ b/src/Axios.js
@@ -8,6 +8,6 @@ export const axiosDefault = axios.create({
 
 export const axiosPrivate = axios.create({
   baseURL: BACKEND_URL,
-  headers: { "Content-Type": "applications/json" },
+  headers: { "Content-Type": "application/json" },
   withCredentials: true,
 });

--- a/src/Components/Account.js
+++ b/src/Components/Account.js
@@ -1,0 +1,28 @@
+import { useNavigate } from "react-router-dom";
+import { axiosDefault } from "../Axios.js";
+import useAuth from "../Hooks/useAuth.js";
+
+export default function Account() {
+  const navigate = useNavigate();
+  const { setAuth } = useAuth();
+
+  const handleSignOut = async () => {
+    try {
+      await axiosDefault.get("/auth/sign-out", {
+        withCredentials: true,
+      });
+      setAuth({});
+      navigate("/");
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
+  return (
+    <div className="App">
+      <header className="App-header">
+        <div onClick={handleSignOut}>Sign out</div>
+      </header>
+    </div>
+  );
+}

--- a/src/Components/EventForm.js
+++ b/src/Components/EventForm.js
@@ -1,20 +1,19 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import axios from "axios";
+import { axiosDefault } from "../Axios.js";
+import useAxiosPrivate from "../Hooks/useAxiosPrivate.js";
 import { storage } from "../Firebase.js";
 import { ref, getDownloadURL, uploadBytes } from "firebase/storage";
 import { Form, FloatingLabel, Button, Spinner } from "react-bootstrap";
 import Select from "react-select";
 import CreatableSelect from "react-select/creatable";
-import { BACKEND_URL } from "../Constants.js";
 import Alerts from "./Alerts.js";
 import { ArrowLeftShort } from "react-bootstrap-icons";
 import moment from "moment";
-import useAuth from "../Hooks/useAuth.js";
 
 export default function EventForm() {
   const navigate = useNavigate();
-  const { auth } = useAuth();
+  const axiosPrivate = useAxiosPrivate();
   const { petId } = useParams();
   const [petProfile, setPetProfile] = useState({});
   const [categoryList, setCategoryList] = useState([]);
@@ -43,9 +42,7 @@ export default function EventForm() {
   }, []);
 
   const retrievePetProfile = async () => {
-    const profile = await axios.get(`${BACKEND_URL}/my-pets/${petId}`, {
-      headers: { Authorization: `Bearer ${auth.token}` },
-    });
+    const profile = await axiosPrivate.get(`/my-pets/${petId}`);
     setPetProfile(profile.data[0]);
   };
 
@@ -54,8 +51,8 @@ export default function EventForm() {
   }, []);
 
   const getCategories = async () => {
-    const categories = await axios.get(
-      `${BACKEND_URL}/my-pets/${petId}/events/categories`
+    const categories = await axiosDefault.get(
+      `/my-pets/${petId}/events/categories`
     );
     setCategoryList(categories.data);
   };
@@ -68,8 +65,8 @@ export default function EventForm() {
     if (!event.categoryId) {
       return;
     }
-    const subcategories = await axios.get(
-      `${BACKEND_URL}/my-pets/${petId}/events/categories/${event.categoryId}/subcategories`
+    const subcategories = await axiosDefault.get(
+      `/my-pets/${petId}/events/categories/${event.categoryId}/subcategories`
     );
     setSubcategoryList(subcategories.data);
   };
@@ -151,8 +148,8 @@ export default function EventForm() {
       return null;
     }
     try {
-      const newSubcategoryRes = await axios.post(
-        `${BACKEND_URL}/my-pets/${petId}/events/categories/${event.categoryId}/subcategories`,
+      const newSubcategoryRes = await axiosDefault.post(
+        `/my-pets/${petId}/events/categories/${event.categoryId}/subcategories`,
         newSubcategory
       );
       return newSubcategoryRes.data.id;
@@ -187,9 +184,7 @@ export default function EventForm() {
       }
     }
     try {
-      await axios.post(`${BACKEND_URL}/my-pets/${petId}/events`, requestBody, {
-        headers: { Authorization: `Bearer ${auth.token}` },
-      });
+      await axiosPrivate.post(`/my-pets/${petId}/events`, requestBody);
     } catch (err) {
       console.log(err);
     }

--- a/src/Components/EventForm.js
+++ b/src/Components/EventForm.js
@@ -6,7 +6,7 @@ import { ref, getDownloadURL, uploadBytes } from "firebase/storage";
 import { Form, FloatingLabel, Button, Spinner } from "react-bootstrap";
 import Select from "react-select";
 import CreatableSelect from "react-select/creatable";
-import { BACKEND_URL, USERID } from "../Constants.js";
+import { BACKEND_URL } from "../Constants.js";
 import Alerts from "./Alerts.js";
 import { ArrowLeftShort } from "react-bootstrap-icons";
 import moment from "moment";
@@ -43,12 +43,9 @@ export default function EventForm() {
   }, []);
 
   const retrievePetProfile = async () => {
-    const profile = await axios.get(
-      `${BACKEND_URL}/users/${USERID}/pets/${petId}`,
-      {
-        headers: { Authorization: `Bearer ${auth.token}` },
-      }
-    );
+    const profile = await axios.get(`${BACKEND_URL}/my-pets/${petId}`, {
+      headers: { Authorization: `Bearer ${auth.token}` },
+    });
     setPetProfile(profile.data[0]);
   };
 
@@ -58,7 +55,7 @@ export default function EventForm() {
 
   const getCategories = async () => {
     const categories = await axios.get(
-      `${BACKEND_URL}/users/${USERID}/pets/${petId}/events/categories`
+      `${BACKEND_URL}/my-pets/${petId}/events/categories`
     );
     setCategoryList(categories.data);
   };
@@ -72,7 +69,7 @@ export default function EventForm() {
       return;
     }
     const subcategories = await axios.get(
-      `${BACKEND_URL}/users/${USERID}/pets/${petId}/events/categories/${event.categoryId}/subcategories`
+      `${BACKEND_URL}/my-pets/${petId}/events/categories/${event.categoryId}/subcategories`
     );
     setSubcategoryList(subcategories.data);
   };
@@ -155,7 +152,7 @@ export default function EventForm() {
     }
     try {
       const newSubcategoryRes = await axios.post(
-        `${BACKEND_URL}/users/${USERID}/pets/${petId}/events/categories/${event.categoryId}/subcategories`,
+        `${BACKEND_URL}/my-pets/${petId}/events/categories/${event.categoryId}/subcategories`,
         newSubcategory
       );
       return newSubcategoryRes.data.id;
@@ -190,10 +187,9 @@ export default function EventForm() {
       }
     }
     try {
-      await axios.post(
-        `${BACKEND_URL}/users/${USERID}/pets/${petId}/events`,
-        requestBody
-      );
+      await axios.post(`${BACKEND_URL}/my-pets/${petId}/events`, requestBody, {
+        headers: { Authorization: `Bearer ${auth.token}` },
+      });
     } catch (err) {
       console.log(err);
     }

--- a/src/Components/EventForm.js
+++ b/src/Components/EventForm.js
@@ -10,9 +10,11 @@ import { BACKEND_URL, USERID } from "../Constants.js";
 import Alerts from "./Alerts.js";
 import { ArrowLeftShort } from "react-bootstrap-icons";
 import moment from "moment";
+import useAuth from "../Hooks/useAuth.js";
 
 export default function EventForm() {
   const navigate = useNavigate();
+  const { auth } = useAuth();
   const { petId } = useParams();
   const [petProfile, setPetProfile] = useState({});
   const [categoryList, setCategoryList] = useState([]);
@@ -42,7 +44,10 @@ export default function EventForm() {
 
   const retrievePetProfile = async () => {
     const profile = await axios.get(
-      `${BACKEND_URL}/users/${USERID}/pets/${petId}`
+      `${BACKEND_URL}/users/${USERID}/pets/${petId}`,
+      {
+        headers: { Authorization: `Bearer ${auth.token}` },
+      }
     );
     setPetProfile(profile.data[0]);
   };

--- a/src/Components/Events.js
+++ b/src/Components/Events.js
@@ -1,16 +1,14 @@
 import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import axios from "axios";
-import { BACKEND_URL } from "../Constants.js";
 import { calculateAge, calculateDuration, sortEventsByDay } from "../Utils.js";
 import { Accordion, Badge } from "react-bootstrap";
 import { PlusCircleFill, ArrowLeftShort } from "react-bootstrap-icons";
-import useAuth from "../Hooks/useAuth.js";
+import useAxiosPrivate from "../Hooks/useAxiosPrivate.js";
 
 export default function Events() {
   const { petId } = useParams();
   const navigate = useNavigate();
-  const { auth } = useAuth();
+  const axiosPrivate = useAxiosPrivate();
 
   const [petProfile, setPetProfile] = useState({});
   const [petEvents, setPetEvents] = useState([]);
@@ -20,9 +18,7 @@ export default function Events() {
   }, []);
 
   const retrievePetProfile = async () => {
-    const profile = await axios.get(`${BACKEND_URL}/my-pets/${petId}`, {
-      headers: { Authorization: `Bearer ${auth.token}` },
-    });
+    const profile = await axiosPrivate.get(`/my-pets/${petId}`);
     setPetProfile(profile.data[0]);
   };
 
@@ -31,9 +27,7 @@ export default function Events() {
   }, []);
 
   const retrievePetEvents = async () => {
-    const events = await axios.get(`${BACKEND_URL}/my-pets/${petId}/events`, {
-      headers: { Authorization: `Bearer ${auth.token}` },
-    });
+    const events = await axiosPrivate.get(`/my-pets/${petId}/events`);
     setPetEvents(events.data);
   };
 

--- a/src/Components/Events.js
+++ b/src/Components/Events.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, useLocation } from "react-router-dom";
 import { calculateAge, calculateDuration, sortEventsByDay } from "../Utils.js";
 import { Accordion, Badge } from "react-bootstrap";
 import { PlusCircleFill, ArrowLeftShort } from "react-bootstrap-icons";
@@ -8,6 +8,7 @@ import useAxiosPrivate from "../Hooks/useAxiosPrivate.js";
 export default function Events() {
   const { petId } = useParams();
   const navigate = useNavigate();
+  const location = useLocation();
   const axiosPrivate = useAxiosPrivate();
 
   const [petProfile, setPetProfile] = useState({});
@@ -18,8 +19,13 @@ export default function Events() {
   }, []);
 
   const retrievePetProfile = async () => {
-    const profile = await axiosPrivate.get(`/my-pets/${petId}`);
-    setPetProfile(profile.data[0]);
+    try {
+      const profile = await axiosPrivate.get(`/my-pets/${petId}`);
+      setPetProfile(profile.data[0]);
+    } catch (err) {
+      console.log(err);
+      navigate("/sign-in", { state: { from: location }, replace: true });
+    }
   };
 
   useEffect(() => {
@@ -27,8 +33,13 @@ export default function Events() {
   }, []);
 
   const retrievePetEvents = async () => {
-    const events = await axiosPrivate.get(`/my-pets/${petId}/events`);
-    setPetEvents(events.data);
+    try {
+      const events = await axiosPrivate.get(`/my-pets/${petId}/events`);
+      setPetEvents(events.data);
+    } catch (err) {
+      console.log(err);
+      navigate("/sign-in", { state: { from: location }, replace: true });
+    }
   };
 
   const displayProfile = () => {

--- a/src/Components/Events.js
+++ b/src/Components/Events.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import axios from "axios";
-import { BACKEND_URL, USERID } from "../Constants.js";
+import { BACKEND_URL } from "../Constants.js";
 import { calculateAge, calculateDuration, sortEventsByDay } from "../Utils.js";
 import { Accordion, Badge } from "react-bootstrap";
 import { PlusCircleFill, ArrowLeftShort } from "react-bootstrap-icons";
@@ -20,10 +20,9 @@ export default function Events() {
   }, []);
 
   const retrievePetProfile = async () => {
-    const profile = await axios.get(
-      `${BACKEND_URL}/users/${USERID}/pets/${petId}`,
-      { headers: { Authorization: `Bearer ${auth.token}` } }
-    );
+    const profile = await axios.get(`${BACKEND_URL}/my-pets/${petId}`, {
+      headers: { Authorization: `Bearer ${auth.token}` },
+    });
     setPetProfile(profile.data[0]);
   };
 
@@ -32,12 +31,9 @@ export default function Events() {
   }, []);
 
   const retrievePetEvents = async () => {
-    const events = await axios.get(
-      `${BACKEND_URL}/users/${USERID}/pets/${petId}/events`,
-      {
-        headers: { Authorization: `Bearer ${auth.token}` },
-      }
-    );
+    const events = await axios.get(`${BACKEND_URL}/my-pets/${petId}/events`, {
+      headers: { Authorization: `Bearer ${auth.token}` },
+    });
     setPetEvents(events.data);
   };
 

--- a/src/Components/Events.js
+++ b/src/Components/Events.js
@@ -5,10 +5,12 @@ import { BACKEND_URL, USERID } from "../Constants.js";
 import { calculateAge, calculateDuration, sortEventsByDay } from "../Utils.js";
 import { Accordion, Badge } from "react-bootstrap";
 import { PlusCircleFill, ArrowLeftShort } from "react-bootstrap-icons";
+import useAuth from "../Hooks/useAuth.js";
 
 export default function Events() {
   const { petId } = useParams();
   const navigate = useNavigate();
+  const { auth } = useAuth();
 
   const [petProfile, setPetProfile] = useState({});
   const [petEvents, setPetEvents] = useState([]);
@@ -19,7 +21,8 @@ export default function Events() {
 
   const retrievePetProfile = async () => {
     const profile = await axios.get(
-      `${BACKEND_URL}/users/${USERID}/pets/${petId}`
+      `${BACKEND_URL}/users/${USERID}/pets/${petId}`,
+      { headers: { Authorization: `Bearer ${auth.token}` } }
     );
     setPetProfile(profile.data[0]);
   };
@@ -30,7 +33,10 @@ export default function Events() {
 
   const retrievePetEvents = async () => {
     const events = await axios.get(
-      `${BACKEND_URL}/users/${USERID}/pets/${petId}/events`
+      `${BACKEND_URL}/users/${USERID}/pets/${petId}/events`,
+      {
+        headers: { Authorization: `Bearer ${auth.token}` },
+      }
     );
     setPetEvents(events.data);
   };

--- a/src/Components/MyPets.js
+++ b/src/Components/MyPets.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import Carousel from "react-bootstrap/Carousel";
 import { calculateAge } from "../Utils.js";
 import { PlusCircleFill } from "react-bootstrap-icons";
@@ -13,6 +13,7 @@ export default function MyPets() {
   const [myPets, setMyPets] = useState([]);
   const [index, setIndex] = useState(0);
   const navigate = useNavigate();
+  const location = useLocation();
   const axiosPrivate = useAxiosPrivate();
 
   useEffect(() => {
@@ -25,6 +26,7 @@ export default function MyPets() {
       setMyPets(pets.data);
     } catch (err) {
       console.log(err);
+      navigate("/sign-in", { state: { from: location }, replace: true });
     }
   };
 
@@ -59,13 +61,6 @@ export default function MyPets() {
   return (
     <div className="App">
       <header className="App-header">
-        {/* <Button
-          onClick={() => {
-            refresh();
-          }}
-        >
-          Refresh token test
-        </Button> */}
         <Reminders />
         <Carousel
           activeIndex={index}

--- a/src/Components/MyPets.js
+++ b/src/Components/MyPets.js
@@ -1,12 +1,14 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import axios from "axios";
-import { BACKEND_URL, USERID } from "../Constants.js";
+import { BACKEND_URL } from "../Constants.js";
 import Carousel from "react-bootstrap/Carousel";
 import { calculateAge } from "../Utils.js";
 import { PlusCircleFill } from "react-bootstrap-icons";
 import Reminders from "./Reminders.js";
 import useAuth from "../Hooks/useAuth.js";
+import useRefreshToken from "../Hooks/useRefreshToken.js";
+import { Button } from "react-bootstrap";
 
 export default function MyPets() {
   const PLACEHOLDER_PIC =
@@ -16,6 +18,7 @@ export default function MyPets() {
   const [index, setIndex] = useState(0);
   const navigate = useNavigate();
   const { auth } = useAuth();
+  const refresh = useRefreshToken();
 
   useEffect(() => {
     retrievePets();
@@ -23,7 +26,7 @@ export default function MyPets() {
 
   const retrievePets = async () => {
     try {
-      const pets = await axios.get(`${BACKEND_URL}/users/${USERID}/pets/`, {
+      const pets = await axios.get(`${BACKEND_URL}/my-pets`, {
         headers: { Authorization: `Bearer ${auth.token}` },
       });
       setMyPets(pets.data);
@@ -63,6 +66,13 @@ export default function MyPets() {
   return (
     <div className="App">
       <header className="App-header">
+        <Button
+          onClick={() => {
+            refresh();
+          }}
+        >
+          Refresh token test
+        </Button>
         <Reminders />
         <Carousel
           activeIndex={index}

--- a/src/Components/MyPets.js
+++ b/src/Components/MyPets.js
@@ -6,6 +6,7 @@ import Carousel from "react-bootstrap/Carousel";
 import { calculateAge } from "../Utils.js";
 import { PlusCircleFill } from "react-bootstrap-icons";
 import Reminders from "./Reminders.js";
+import useAuth from "../Hooks/useAuth.js";
 
 export default function MyPets() {
   const PLACEHOLDER_PIC =
@@ -14,14 +15,21 @@ export default function MyPets() {
   const [myPets, setMyPets] = useState([]);
   const [index, setIndex] = useState(0);
   const navigate = useNavigate();
+  const { auth } = useAuth();
 
   useEffect(() => {
     retrievePets();
   }, []);
 
   const retrievePets = async () => {
-    const pets = await axios.get(`${BACKEND_URL}/users/${USERID}/pets/`);
-    setMyPets(pets.data);
+    try {
+      const pets = await axios.get(`${BACKEND_URL}/users/${USERID}/pets/`, {
+        headers: { Authorization: `Bearer ${auth.token}` },
+      });
+      setMyPets(pets.data);
+    } catch (err) {
+      console.log(err);
+    }
   };
 
   const displayPets = () => {
@@ -56,7 +64,6 @@ export default function MyPets() {
     <div className="App">
       <header className="App-header">
         <Reminders />
-        {/* Note: authenticated users see a summary of pet profiles */}
         <Carousel
           activeIndex={index}
           onSelect={handleSelect}

--- a/src/Components/MyPets.js
+++ b/src/Components/MyPets.js
@@ -1,14 +1,10 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import axios from "axios";
-import { BACKEND_URL } from "../Constants.js";
 import Carousel from "react-bootstrap/Carousel";
 import { calculateAge } from "../Utils.js";
 import { PlusCircleFill } from "react-bootstrap-icons";
 import Reminders from "./Reminders.js";
-import useAuth from "../Hooks/useAuth.js";
-import useRefreshToken from "../Hooks/useRefreshToken.js";
-import { Button } from "react-bootstrap";
+import useAxiosPrivate from "../Hooks/useAxiosPrivate.js";
 
 export default function MyPets() {
   const PLACEHOLDER_PIC =
@@ -17,8 +13,7 @@ export default function MyPets() {
   const [myPets, setMyPets] = useState([]);
   const [index, setIndex] = useState(0);
   const navigate = useNavigate();
-  const { auth } = useAuth();
-  const refresh = useRefreshToken();
+  const axiosPrivate = useAxiosPrivate();
 
   useEffect(() => {
     retrievePets();
@@ -26,9 +21,7 @@ export default function MyPets() {
 
   const retrievePets = async () => {
     try {
-      const pets = await axios.get(`${BACKEND_URL}/my-pets`, {
-        headers: { Authorization: `Bearer ${auth.token}` },
-      });
+      const pets = await axiosPrivate.get("/my-pets");
       setMyPets(pets.data);
     } catch (err) {
       console.log(err);
@@ -66,13 +59,13 @@ export default function MyPets() {
   return (
     <div className="App">
       <header className="App-header">
-        <Button
+        {/* <Button
           onClick={() => {
             refresh();
           }}
         >
           Refresh token test
-        </Button>
+        </Button> */}
         <Reminders />
         <Carousel
           activeIndex={index}

--- a/src/Components/Navigation.js
+++ b/src/Components/Navigation.js
@@ -7,7 +7,13 @@ export default function Navigation() {
   return (
     <Navbar bg="dark" variant="dark" fixed="bottom">
       <Nav>
-        <Nav.Link>Account</Nav.Link>
+        <Nav.Link
+          onClick={() => {
+            navigate("/account");
+          }}
+        >
+          Account
+        </Nav.Link>
         <Nav.Link>Feed</Nav.Link>
         <Nav.Link
           onClick={() => {

--- a/src/Components/PersistLogin.js
+++ b/src/Components/PersistLogin.js
@@ -1,0 +1,12 @@
+import { useEffect, useState } from "react";
+import { Outlet } from "react-router-dom";
+import useAuth from "../Hooks/useAuth.js";
+
+export default function PersistLogin() {
+  const [isLoading, setIsLoading] = useState(true);
+  const { auth } = useAuth();
+
+  useEffect(() => {
+    const verifyToken = async () => {};
+  }, []);
+}

--- a/src/Components/PersistLogin.js
+++ b/src/Components/PersistLogin.js
@@ -1,12 +1,26 @@
 import { useEffect, useState } from "react";
 import { Outlet } from "react-router-dom";
+import useRefreshToken from "../Hooks/useRefreshToken.js";
 import useAuth from "../Hooks/useAuth.js";
 
 export default function PersistLogin() {
   const [isLoading, setIsLoading] = useState(true);
+  const refresh = useRefreshToken();
   const { auth } = useAuth();
 
   useEffect(() => {
-    const verifyToken = async () => {};
+    const verifyRefreshToken = async () => {
+      try {
+        await refresh();
+      } catch (err) {
+        console.log(err);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    !auth?.token ? verifyRefreshToken() : setIsLoading(false);
   }, []);
+
+  return <>{isLoading ? <div>Loading...</div> : <Outlet />}</>;
 }

--- a/src/Components/PetForm.js
+++ b/src/Components/PetForm.js
@@ -5,12 +5,14 @@ import { storage } from "../Firebase.js";
 import { ref, getDownloadURL, uploadBytes } from "firebase/storage";
 import { Form, FloatingLabel, Button, Spinner } from "react-bootstrap";
 import Select from "react-select";
-import { BACKEND_URL, USERID } from "../Constants.js";
+import { BACKEND_URL } from "../Constants.js";
 import Alerts from "./Alerts.js";
 import { ArrowLeftShort } from "react-bootstrap-icons";
+import useAuth from "../Hooks/useAuth.js";
 
 export default function PetForm() {
   const navigate = useNavigate();
+  const { auth } = useAuth();
   const [speciesList, setSpeciesList] = useState([]);
   const [breedsList, setBreedsList] = useState([]);
   const [profile, setProfile] = useState({
@@ -30,9 +32,7 @@ export default function PetForm() {
   }, []);
 
   const getSpecies = async () => {
-    const species = await axios.get(
-      `${BACKEND_URL}/users/${USERID}/pets/species`
-    );
+    const species = await axios.get(`${BACKEND_URL}/my-pets/species`);
     setSpeciesList(species.data);
   };
 
@@ -45,7 +45,7 @@ export default function PetForm() {
       return;
     }
     const breeds = await axios.get(
-      `${BACKEND_URL}/users/${USERID}/pets/species/${profile.speciesId}/breeds`
+      `${BACKEND_URL}/my-pets/species/${profile.speciesId}/breeds`
     );
     setBreedsList(breeds.data);
   };
@@ -97,7 +97,9 @@ export default function PetForm() {
         delete requestBody[key];
       }
     }
-    await axios.post(`${BACKEND_URL}/users/${USERID}/pets/`, requestBody);
+    await axios.post(`${BACKEND_URL}/my-pets`, requestBody, {
+      headers: { Authorization: `Bearer ${auth.token}` },
+    });
     setProfile({
       speciesId: "",
       breedId: "",

--- a/src/Components/PetForm.js
+++ b/src/Components/PetForm.js
@@ -1,18 +1,17 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import axios from "axios";
 import { storage } from "../Firebase.js";
 import { ref, getDownloadURL, uploadBytes } from "firebase/storage";
 import { Form, FloatingLabel, Button, Spinner } from "react-bootstrap";
 import Select from "react-select";
-import { BACKEND_URL } from "../Constants.js";
 import Alerts from "./Alerts.js";
 import { ArrowLeftShort } from "react-bootstrap-icons";
-import useAuth from "../Hooks/useAuth.js";
+import { axiosDefault } from "../Axios.js";
+import useAxiosPrivate from "../Hooks/useAxiosPrivate.js";
 
 export default function PetForm() {
   const navigate = useNavigate();
-  const { auth } = useAuth();
+  const axiosPrivate = useAxiosPrivate();
   const [speciesList, setSpeciesList] = useState([]);
   const [breedsList, setBreedsList] = useState([]);
   const [profile, setProfile] = useState({
@@ -32,7 +31,7 @@ export default function PetForm() {
   }, []);
 
   const getSpecies = async () => {
-    const species = await axios.get(`${BACKEND_URL}/my-pets/species`);
+    const species = await axiosDefault.get("/my-pets/species");
     setSpeciesList(species.data);
   };
 
@@ -44,8 +43,8 @@ export default function PetForm() {
     if (!profile.speciesId) {
       return;
     }
-    const breeds = await axios.get(
-      `${BACKEND_URL}/my-pets/species/${profile.speciesId}/breeds`
+    const breeds = await axiosDefault.get(
+      `/my-pets/species/${profile.speciesId}/breeds`
     );
     setBreedsList(breeds.data);
   };
@@ -97,9 +96,7 @@ export default function PetForm() {
         delete requestBody[key];
       }
     }
-    await axios.post(`${BACKEND_URL}/my-pets`, requestBody, {
-      headers: { Authorization: `Bearer ${auth.token}` },
-    });
+    await axiosPrivate.post("/my-pets", requestBody);
     setProfile({
       speciesId: "",
       breedId: "",

--- a/src/Components/PetForm.js
+++ b/src/Components/PetForm.js
@@ -31,8 +31,12 @@ export default function PetForm() {
   }, []);
 
   const getSpecies = async () => {
-    const species = await axiosDefault.get("/my-pets/species");
-    setSpeciesList(species.data);
+    try {
+      const species = await axiosDefault.get("/my-pets/species");
+      setSpeciesList(species.data);
+    } catch (err) {
+      console.log(err);
+    }
   };
 
   useEffect(() => {
@@ -43,10 +47,14 @@ export default function PetForm() {
     if (!profile.speciesId) {
       return;
     }
-    const breeds = await axiosDefault.get(
-      `/my-pets/species/${profile.speciesId}/breeds`
-    );
-    setBreedsList(breeds.data);
+    try {
+      const breeds = await axiosDefault.get(
+        `/my-pets/species/${profile.speciesId}/breeds`
+      );
+      setBreedsList(breeds.data);
+    } catch (err) {
+      console.log(err);
+    }
   };
 
   const handleSelect = (selected) => {

--- a/src/Components/Reminders.js
+++ b/src/Components/Reminders.js
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import axios from "axios";
 import { ToastContainer, Toast } from "react-bootstrap";
 import { AlarmFill } from "react-bootstrap-icons";
-import { BACKEND_URL, USERID } from "../Constants.js";
+import { BACKEND_URL } from "../Constants.js";
 import useAuth from "../Hooks/useAuth.js";
 
 export default function Reminders(props) {
@@ -14,12 +14,9 @@ export default function Reminders(props) {
   }, []);
 
   const getReminders = async () => {
-    const remindersRes = await axios.get(
-      `${BACKEND_URL}/users/${USERID}/reminders`,
-      {
-        headers: { Authorization: `Bearer ${auth.token}` },
-      }
-    );
+    const remindersRes = await axios.get(`${BACKEND_URL}/my-reminders`, {
+      headers: { Authorization: `Bearer ${auth.token}` },
+    });
     setReminders(remindersRes.data);
   };
 

--- a/src/Components/Reminders.js
+++ b/src/Components/Reminders.js
@@ -1,9 +1,12 @@
 import { useEffect, useState } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
 import { ToastContainer, Toast } from "react-bootstrap";
 import { AlarmFill } from "react-bootstrap-icons";
 import useAxiosPrivate from "../Hooks/useAxiosPrivate.js";
 
 export default function Reminders(props) {
+  const navigate = useNavigate();
+  const location = useLocation();
   const axiosPrivate = useAxiosPrivate();
   const [reminders, setReminders] = useState([]);
 
@@ -12,8 +15,13 @@ export default function Reminders(props) {
   }, []);
 
   const getReminders = async () => {
-    const remindersRes = await axiosPrivate.get("/my-reminders");
-    setReminders(remindersRes.data);
+    try {
+      const remindersRes = await axiosPrivate.get("/my-reminders");
+      setReminders(remindersRes.data);
+    } catch (err) {
+      console.log(err);
+      navigate("/sign-in", { state: { from: location }, replace: true });
+    }
   };
 
   const displayToasts = () => {

--- a/src/Components/Reminders.js
+++ b/src/Components/Reminders.js
@@ -3,8 +3,10 @@ import axios from "axios";
 import { ToastContainer, Toast } from "react-bootstrap";
 import { AlarmFill } from "react-bootstrap-icons";
 import { BACKEND_URL, USERID } from "../Constants.js";
+import useAuth from "../Hooks/useAuth.js";
 
 export default function Reminders(props) {
+  const { auth } = useAuth();
   const [reminders, setReminders] = useState([]);
 
   useEffect(() => {
@@ -13,7 +15,10 @@ export default function Reminders(props) {
 
   const getReminders = async () => {
     const remindersRes = await axios.get(
-      `${BACKEND_URL}/users/${USERID}/reminders`
+      `${BACKEND_URL}/users/${USERID}/reminders`,
+      {
+        headers: { Authorization: `Bearer ${auth.token}` },
+      }
     );
     setReminders(remindersRes.data);
   };

--- a/src/Components/Reminders.js
+++ b/src/Components/Reminders.js
@@ -1,12 +1,10 @@
 import { useEffect, useState } from "react";
-import axios from "axios";
 import { ToastContainer, Toast } from "react-bootstrap";
 import { AlarmFill } from "react-bootstrap-icons";
-import { BACKEND_URL } from "../Constants.js";
-import useAuth from "../Hooks/useAuth.js";
+import useAxiosPrivate from "../Hooks/useAxiosPrivate.js";
 
 export default function Reminders(props) {
-  const { auth } = useAuth();
+  const axiosPrivate = useAxiosPrivate();
   const [reminders, setReminders] = useState([]);
 
   useEffect(() => {
@@ -14,9 +12,7 @@ export default function Reminders(props) {
   }, []);
 
   const getReminders = async () => {
-    const remindersRes = await axios.get(`${BACKEND_URL}/my-reminders`, {
-      headers: { Authorization: `Bearer ${auth.token}` },
-    });
+    const remindersRes = await axiosPrivate.get("/my-reminders");
     setReminders(remindersRes.data);
   };
 

--- a/src/Components/RequireAuth.js
+++ b/src/Components/RequireAuth.js
@@ -5,7 +5,7 @@ export default function RequireAuth() {
   const { auth } = useAuth();
   const location = useLocation();
 
-  return auth?.email ? (
+  return auth?.token ? (
     <Outlet />
   ) : (
     <Navigate to="/sign-in" state={{ from: location }} replace />

--- a/src/Components/RequireAuth.js
+++ b/src/Components/RequireAuth.js
@@ -1,0 +1,13 @@
+import { useLocation, Navigate, Outlet } from "react-router-dom";
+import useAuth from "../Hooks/useAuth";
+
+export default function RequireAuth() {
+  const { auth } = useAuth();
+  const location = useLocation();
+
+  return auth?.email ? (
+    <Outlet />
+  ) : (
+    <Navigate to="/sign-in" state={{ from: location }} replace />
+  );
+}

--- a/src/Components/SignIn.js
+++ b/src/Components/SignIn.js
@@ -9,7 +9,6 @@ export default function SignIn() {
   const { setAuth } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
-  const axiosPrivate = useAxiosPrivate();
   const from = location.state?.from?.pathname || "/";
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -38,9 +37,8 @@ export default function SignIn() {
         },
         { withCredentials: true }
       );
-      const { token, refreshToken } = signInRes.data;
-      const profile = await axiosPrivate.get("/user-profile");
-      setAuth({ ...profile.data, token, refreshToken });
+      const { token } = signInRes.data;
+      setAuth({ token });
       setEmail("");
       setPassword("");
       navigate(from, { replace: true }); // Navigate to where the user was before they were redirected to sign-in

--- a/src/Components/SignIn.js
+++ b/src/Components/SignIn.js
@@ -1,0 +1,94 @@
+import { useState } from "react";
+import useAuth from "../Hooks/useAuth.js";
+import axios from "axios";
+import { useNavigate, useLocation, Link } from "react-router-dom";
+import { BACKEND_URL } from "../Constants.js";
+import { Form, FloatingLabel, Button } from "react-bootstrap";
+
+export default function SignIn() {
+  const { setAuth } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const from = location.state?.from?.pathname || "/";
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const handleChange = (e) => {
+    let { name, value } = e.target;
+    if (name === "email") {
+      setEmail(value);
+    }
+    if (name === "password") {
+      setPassword(value);
+    }
+  };
+
+  const signIn = async (e) => {
+    e.preventDefault();
+    if (!email || !password) {
+      alert("Please provide your email and password!");
+    }
+    try {
+      const signInRes = await axios.post(
+        `${BACKEND_URL}/auth/sign-in`,
+        {
+          email,
+          password,
+        },
+        { withCredentials: true }
+      );
+      const { token, refreshToken, id } = signInRes.data;
+      const profile = await axios.get(`${BACKEND_URL}/users/${id}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      setAuth({ ...profile.data, token, refreshToken });
+      setEmail("");
+      setPassword("");
+      navigate(from, { replace: true }); // Navigate to where the user was before they were redirected to sign-in
+    } catch (err) {
+      console.log(err);
+      alert(err.response.data.msg);
+    }
+  };
+
+  return (
+    <div className="App">
+      <header className="App-header">
+        <h1 className="large bold">Log in</h1>
+        <Form className="margin-lr-m" onSubmit={signIn}>
+          <Form.Group className="margin-tb-m">
+            <FloatingLabel label="Email" className="dark">
+              <Form.Control
+                name="email"
+                type="email"
+                value={email}
+                onChange={handleChange}
+                placeholder="my@email.com"
+                autoFocus
+              />
+            </FloatingLabel>
+          </Form.Group>
+          <Form.Group className="margin-tb-m">
+            <FloatingLabel label="Password" className="dark">
+              <Form.Control
+                name="password"
+                type="password"
+                value={password}
+                placeholder="12345"
+                onChange={handleChange}
+              />
+            </FloatingLabel>
+          </Form.Group>
+          <Form.Group className="margin-tb-m">
+            <Button variant="light" type="submit">
+              Log in
+            </Button>
+          </Form.Group>
+          <Form.Group className="margin-tb-m">
+            Need an account? <Link to="/">Sign up</Link>
+          </Form.Group>
+        </Form>
+      </header>
+    </div>
+  );
+}

--- a/src/Components/SignIn.js
+++ b/src/Components/SignIn.js
@@ -37,8 +37,8 @@ export default function SignIn() {
         },
         { withCredentials: true }
       );
-      const { token, refreshToken, id } = signInRes.data;
-      const profile = await axios.get(`${BACKEND_URL}/users/${id}`, {
+      const { token, refreshToken } = signInRes.data;
+      const profile = await axios.get(`${BACKEND_URL}/user-profile`, {
         headers: { Authorization: `Bearer ${token}` },
       });
       setAuth({ ...profile.data, token, refreshToken });

--- a/src/Components/SignIn.js
+++ b/src/Components/SignIn.js
@@ -1,14 +1,15 @@
 import { useState } from "react";
 import useAuth from "../Hooks/useAuth.js";
-import axios from "axios";
 import { useNavigate, useLocation, Link } from "react-router-dom";
-import { BACKEND_URL } from "../Constants.js";
+import { axiosDefault } from "../Axios.js";
+import useAxiosPrivate from "../Hooks/useAxiosPrivate.js";
 import { Form, FloatingLabel, Button } from "react-bootstrap";
 
 export default function SignIn() {
   const { setAuth } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
+  const axiosPrivate = useAxiosPrivate();
   const from = location.state?.from?.pathname || "/";
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -29,8 +30,8 @@ export default function SignIn() {
       alert("Please provide your email and password!");
     }
     try {
-      const signInRes = await axios.post(
-        `${BACKEND_URL}/auth/sign-in`,
+      const signInRes = await axiosDefault.post(
+        "/auth/sign-in",
         {
           email,
           password,
@@ -38,9 +39,7 @@ export default function SignIn() {
         { withCredentials: true }
       );
       const { token, refreshToken } = signInRes.data;
-      const profile = await axios.get(`${BACKEND_URL}/user-profile`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
+      const profile = await axiosPrivate.get("/user-profile");
       setAuth({ ...profile.data, token, refreshToken });
       setEmail("");
       setPassword("");

--- a/src/Constants.js
+++ b/src/Constants.js
@@ -1,4 +1,4 @@
 export const BACKEND_URL = "http://localhost:3000";
 
 // Hard coded - to be replaced when auth is in place
-export const USERID = 1;
+// export const USERID = 1;

--- a/src/Constants.js
+++ b/src/Constants.js
@@ -1,4 +1,0 @@
-export const BACKEND_URL = "http://localhost:3000";
-
-// Hard coded - to be replaced when auth is in place
-// export const USERID = 1;

--- a/src/Context/AuthProvider.js
+++ b/src/Context/AuthProvider.js
@@ -1,0 +1,15 @@
+import { createContext, useState } from "react";
+
+const AuthContext = createContext({});
+
+export const AuthProvider = ({ children }) => {
+  const [auth, setAuth] = useState({});
+
+  return (
+    <AuthContext.Provider value={{ auth, setAuth }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export default AuthContext;

--- a/src/Hooks/useAuth.js
+++ b/src/Hooks/useAuth.js
@@ -1,0 +1,6 @@
+import { useContext } from "react";
+import AuthContext from "../Context/AuthProvider.js";
+
+export default function useAuth() {
+  return useContext(AuthContext);
+}

--- a/src/Hooks/useAxiosPrivate.js
+++ b/src/Hooks/useAxiosPrivate.js
@@ -1,0 +1,46 @@
+import { useEffect } from "react";
+import { axiosPrivate } from "../Axios.js";
+import useRefreshToken from "./useRefreshToken.js";
+import useAuth from "./useAuth.js";
+
+export default function useAxiosPrivate() {
+  const refresh = useRefreshToken();
+  const { auth } = useAuth();
+
+  // Attach and remove axios interceptors
+  useEffect(() => {
+    const requestIntercept = axiosPrivate.interceptors.request.use(
+      (config) => {
+        if (!config.headers["Authorization"]) {
+          // If this is the first attempt to intercept, put token into headers
+          config.headers["Authorization"] = `Bearer ${auth?.token}`;
+        }
+        return config;
+      },
+      (err) => {
+        Promise.reject(err);
+      }
+    );
+
+    const responseIntercept = axiosPrivate.interceptors.response.use(
+      (response) => response,
+      async (err) => {
+        const prevReq = err?.config;
+        if (err?.response?.status === 403 && !prevReq.sent) {
+          prevReq.sent = true;
+          const newToken = await refresh();
+          prevReq.headers["Authorization"] = `Bearer ${newToken}`;
+          return axiosPrivate(prevReq);
+        }
+        return Promise.reject(err);
+      }
+    );
+
+    return () => {
+      axiosPrivate.interceptors.request.eject(requestIntercept);
+      axiosPrivate.interceptors.response.eject(responseIntercept);
+    };
+  }, [auth, refresh]);
+
+  return axiosPrivate;
+}

--- a/src/Hooks/useRefreshToken.js
+++ b/src/Hooks/useRefreshToken.js
@@ -1,12 +1,11 @@
-import useAuth from "./useAuth";
-import axios from "axios";
-import { BACKEND_URL } from "../Constants.js";
+import useAuth from "./useAuth.js";
+import { axiosDefault } from "../Axios.js";
 
 export default function useRefreshToken() {
   const { setAuth } = useAuth();
 
   const refresh = async () => {
-    const response = await axios.get(`${BACKEND_URL}/auth/refresh`, {
+    const response = await axiosDefault.get("/auth/refresh", {
       withCredentials: true,
     });
 

--- a/src/Hooks/useRefreshToken.js
+++ b/src/Hooks/useRefreshToken.js
@@ -1,0 +1,21 @@
+import useAuth from "./useAuth";
+import axios from "axios";
+import { BACKEND_URL } from "../Constants.js";
+
+export default function useRefreshToken() {
+  const { setAuth } = useAuth();
+
+  const refresh = async () => {
+    const response = await axios.get(`${BACKEND_URL}/auth/refresh`, {
+      withCredentials: true,
+    });
+
+    setAuth((prevState) => {
+      return { ...prevState, token: response.data.token };
+    });
+
+    return response.data.token;
+  };
+
+  return refresh;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import "./index.css";
 import { AuthProvider } from "./Context/AuthProvider.js";
+import PersistLogin from "./Components/PersistLogin.js";
 import RequireAuth from "./Components/RequireAuth.js";
 import App from "./App.js";
 import MyPets from "./Components/MyPets.js";
@@ -25,14 +26,19 @@ root.render(
         <Route path="/account" element={<Account />} />
         {/* New user sign up page goes here */}
 
-        {/* Protected routes */}
-        <Route element={<RequireAuth />}>
-          <Route path="/my-pets" element={<MyPets />} />
-          <Route path="/my-pets/add-pet" element={<PetForm />} />
-          <Route path="/my-pets/:petId" element={<Events />} />
-          <Route path="/my-pets/:petId/add-activity" element={<EventForm />} />
+        {/* Protected routes that require auth */}
+        <Route element={<PersistLogin />}>
+          <Route element={<RequireAuth />}>
+            <Route path="/my-pets" element={<MyPets />} />
+            <Route path="/my-pets/add-pet" element={<PetForm />} />
+            <Route path="/my-pets/:petId" element={<Events />} />
+            <Route
+              path="/my-pets/:petId/add-activity"
+              element={<EventForm />}
+            />
+          </Route>
         </Route>
-        {/* Catch-all */}
+        {/* Catch-all for invalid URLs */}
         {/* <Route path="*" element={}/> */}
       </Routes>
     </AuthProvider>

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import Navigation from "./Components/Navigation.js";
 import Events from "./Components/Events.js";
 import PetForm from "./Components/PetForm.js";
 import EventForm from "./Components/EventForm.js";
+import Account from "./Components/Account.js";
 import SignIn from "./Components/SignIn.js";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
@@ -21,6 +22,7 @@ root.render(
         {/* Public routes */}
         <Route path="/" element={<App />} />
         <Route path="/sign-in" element={<SignIn />} />
+        <Route path="/account" element={<Account />} />
         {/* New user sign up page goes here */}
 
         {/* Protected routes */}

--- a/src/index.js
+++ b/src/index.js
@@ -2,23 +2,37 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import "./index.css";
+import { AuthProvider } from "./Context/AuthProvider.js";
+import RequireAuth from "./Components/RequireAuth.js";
 import App from "./App.js";
 import MyPets from "./Components/MyPets.js";
 import Navigation from "./Components/Navigation.js";
 import Events from "./Components/Events.js";
 import PetForm from "./Components/PetForm.js";
 import EventForm from "./Components/EventForm.js";
+import SignIn from "./Components/SignIn.js";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <BrowserRouter>
-    <Navigation />
-    <Routes>
-      <Route path="/" element={<App />} />
-      <Route path="/my-pets" element={<MyPets />} />
-      <Route path="/my-pets/add-pet" element={<PetForm />} />
-      <Route path="/my-pets/:petId" element={<Events />} />
-      <Route path="/my-pets/:petId/add-activity" element={<EventForm />} />
-    </Routes>
+    <AuthProvider>
+      <Navigation />
+      <Routes>
+        {/* Public routes */}
+        <Route path="/" element={<App />} />
+        <Route path="/sign-in" element={<SignIn />} />
+        {/* New user sign up page goes here */}
+
+        {/* Protected routes */}
+        <Route element={<RequireAuth />}>
+          <Route path="/my-pets" element={<MyPets />} />
+          <Route path="/my-pets/add-pet" element={<PetForm />} />
+          <Route path="/my-pets/:petId" element={<Events />} />
+          <Route path="/my-pets/:petId/add-activity" element={<EventForm />} />
+        </Route>
+        {/* Catch-all */}
+        {/* <Route path="*" element={}/> */}
+      </Routes>
+    </AuthProvider>
   </BrowserRouter>
 );


### PR DESCRIPTION
New HOC, custom hooks, and sign in component to authenticate a user using JWT, and let the user stay logged in until the refresh token expires.

Expect to see 403 errors once in a while (e.g. first log in, or when the token refreshes). This is because HTTP requests to protected backend routes are made using a custom Axios instance (src > Axios.js) with interceptors (src > Hooks > useAxiosPrivate.js). The interceptors listen for the first login event, or a response with 403 status (hence the occasional 403 error), and attaches the auth token to the HTTP request header.

Users can log out under the "Account" tab - this will be improved in subsequent phases.